### PR TITLE
fix(email): granular SMTP error logging, SMTP_SSL on port 465, /auth/…

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -1,6 +1,6 @@
 import os
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Header, HTTPException
 from sqlalchemy.orm import Session
 
 try:
@@ -76,6 +76,31 @@ def password_forgot(payload: PasswordForgotBody, db: Session = Depends(get_db)):
 @router.post("/auth/password/reset", response_model=PasswordResetResponse)
 def password_reset(payload: PasswordResetBody, db: Session = Depends(get_db)):
     return reset_password(payload=payload, db=db)
+
+
+@router.get("/auth/email-test")
+def email_test(x_admin_key: str = Header(None)):
+    """Send a test email to ADMIN_EMAIL. Protected by X-Admin-Key header."""
+    if not ADMIN_EXPORT_KEY or x_admin_key != ADMIN_EXPORT_KEY:
+        raise HTTPException(status_code=403, detail="Forbidden: provide X-Admin-Key header")
+    try:
+        from ..services.transactional_email import send_transactional_email
+    except ImportError:
+        from services.transactional_email import send_transactional_email  # type: ignore
+    to = (ADMIN_EMAIL or "").strip()
+    if not to:
+        raise HTTPException(status_code=400, detail="ADMIN_EMAIL is not configured")
+    ok = send_transactional_email(
+        to,
+        "CAL email test",
+        "If you received this, outbound email is configured correctly on Render.",
+        "<p>If you received this, outbound email is configured correctly on Render.</p>",
+    )
+    provider = email_provider_hint()
+    if ok:
+        return {"status": "ok", "sent_to": to, "provider": provider}
+    return {"status": "failed", "sent_to": to, "provider": provider,
+            "hint": "Check Render logs for the exact SMTP/Resend error."}
 
 
 @router.get("/auth/config-status")

--- a/backend/services/magic_link_service.py
+++ b/backend/services/magic_link_service.py
@@ -1,6 +1,7 @@
 import hashlib
 import secrets
 import smtplib
+import traceback
 from datetime import datetime, timedelta, timezone
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
@@ -108,7 +109,7 @@ def _send_via_resend(to_email: str, magic_url: str) -> bool:
             )
         return r.status_code in (200, 201)
     except Exception as e:
-        print(f"Warning: Resend magic link email failed: {e}")
+        print(f"Warning: Resend magic link email failed [{type(e).__name__}]: {e}")
         return False
 
 
@@ -127,14 +128,39 @@ def _send_via_smtp(to_email: str, magic_url: str) -> bool:
         msg.attach(MIMEText(html, "html"))
 
         _, envelope_from = parseaddr(SMTP_FROM)
-        with smtplib.SMTP(SMTP_HOST, port, timeout=30) as server:
-            server.starttls()
+        # Port 465 uses SSL-from-the-start; port 587 (and others) use STARTTLS upgrade.
+        if port == 465:
+            smtp_cls = smtplib.SMTP_SSL
+            use_starttls = False
+        else:
+            smtp_cls = smtplib.SMTP
+            use_starttls = True
+        with smtp_cls(SMTP_HOST, port, timeout=30) as server:
+            if use_starttls:
+                server.starttls()
             if SMTP_USER and SMTP_PASSWORD:
                 server.login(SMTP_USER, SMTP_PASSWORD)
             server.sendmail(envelope_from or SMTP_FROM, [to_email], msg.as_string())
         return True
+    except smtplib.SMTPAuthenticationError as e:
+        print(
+            f"Warning: SMTP auth failed for user '{SMTP_USER}' on {SMTP_HOST}:{SMTP_PORT}. "
+            f"For Gmail, ensure 2FA is enabled and SMTP_PASSWORD is a 16-char App Password "
+            f"(no spaces). Error: {e}"
+        )
+        return False
+    except (ConnectionRefusedError, TimeoutError, OSError) as e:
+        print(
+            f"Warning: SMTP connection to {SMTP_HOST}:{SMTP_PORT} failed [{type(e).__name__}]: {e}. "
+            f"Cloud providers often block outbound SMTP — consider switching to RESEND_API_KEY."
+        )
+        return False
+    except smtplib.SMTPException as e:
+        print(f"Warning: SMTP magic link email failed [{type(e).__name__}]: {e}")
+        return False
     except Exception as e:
-        print(f"Warning: SMTP magic link email failed: {e}")
+        print(f"Warning: SMTP magic link email unexpected error [{type(e).__name__}]: {e}")
+        traceback.print_exc()
         return False
 
 

--- a/backend/services/transactional_email.py
+++ b/backend/services/transactional_email.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import base64
 import smtplib
+import traceback
 from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
@@ -95,7 +96,7 @@ def send_transactional_email(
                 )
             return r.status_code in (200, 201)
         except Exception as e:
-            print(f"Warning: Resend transactional email failed: {e}")
+            print(f"Warning: Resend transactional email failed [{type(e).__name__}]: {e}")
             return False
 
     if SMTP_HOST and SMTP_FROM:
@@ -118,14 +119,39 @@ def send_transactional_email(
                 part.add_header("Content-Disposition", "attachment", filename=attachment_filename)
                 msg.attach(part)
             _, envelope_from = parseaddr(SMTP_FROM)
-            with smtplib.SMTP(SMTP_HOST, port, timeout=30) as server:
-                server.starttls()
+            # Port 465 uses SSL-from-the-start; port 587 (and others) use STARTTLS upgrade.
+            if port == 465:
+                smtp_cls = smtplib.SMTP_SSL
+                use_starttls = False
+            else:
+                smtp_cls = smtplib.SMTP
+                use_starttls = True
+            with smtp_cls(SMTP_HOST, port, timeout=30) as server:
+                if use_starttls:
+                    server.starttls()
                 if SMTP_USER and SMTP_PASSWORD:
                     server.login(SMTP_USER, SMTP_PASSWORD)
                 server.sendmail(envelope_from or SMTP_FROM, [to_email], msg.as_string())
             return True
+        except smtplib.SMTPAuthenticationError as e:
+            print(
+                f"Warning: SMTP auth failed for user '{SMTP_USER}' on {SMTP_HOST}:{SMTP_PORT}. "
+                f"For Gmail, ensure 2FA is enabled and SMTP_PASSWORD is a 16-char App Password "
+                f"(no spaces). Error: {e}"
+            )
+            return False
+        except (ConnectionRefusedError, TimeoutError, OSError) as e:
+            print(
+                f"Warning: SMTP connection to {SMTP_HOST}:{SMTP_PORT} failed [{type(e).__name__}]: {e}. "
+                f"Cloud providers often block outbound SMTP — consider switching to RESEND_API_KEY."
+            )
+            return False
+        except smtplib.SMTPException as e:
+            print(f"Warning: SMTP transactional email failed [{type(e).__name__}]: {e}")
+            return False
         except Exception as e:
-            print(f"Warning: SMTP transactional email failed: {e}")
+            print(f"Warning: SMTP transactional email unexpected error [{type(e).__name__}]: {e}")
+            traceback.print_exc()
             return False
 
     print("Warning: No email provider configured (RESEND_API_KEY or SMTP_HOST + SMTP_FROM).")


### PR DESCRIPTION
…email-test endpoint

- SMTPAuthenticationError, ConnectionRefusedError, and generic SMTP exceptions now log distinct messages with the exception type so Render logs pinpoint the cause
- Port 465 now uses SMTP_SSL instead of STARTTLS (port 587 unchanged)
- GET /auth/email-test (X-Admin-Key protected) sends a test email to ADMIN_EMAIL for one-call diagnosis without going through the real sign-in flow